### PR TITLE
Changed matches condition

### DIFF
--- a/built/index.js
+++ b/built/index.js
@@ -58,7 +58,7 @@ function _checkPullRequestFormat(expressions, body) {
             matches += 1;
         }
     }
-    return compiled.length === matches;
+    return matches > 0;
 }
 (function () {
     try {

--- a/dist/index.js
+++ b/dist/index.js
@@ -5837,7 +5837,7 @@ function _checkPullRequestFormat(expressions, body) {
     }
   }
 
-  return compiled.length === matches;
+  return matches > 0;
 }
 
 (function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ function _checkPullRequestFormat(expressions: string[], body: string): boolean {
       matches += 1;
     }
   }
-  return compiled.length === matches;
+  return matches > 0;
 }
 
 


### PR DESCRIPTION
Hi

I used your checker and found a problem that when I have one regular expression and there is more than 1 match in the PR body, the `_checkPullRequestFormat` function returns `false`.

So, I just pushed a fix that returns `true` all the time when `matches > 0`

Thanks